### PR TITLE
Прорастить призыв диалога маски в объект hvScriptSet

### DIFF
--- a/hvss.js
+++ b/hvss.js
@@ -1194,5 +1194,9 @@ const hvScriptSet = {
     $(document).on('pun_edit', () => getPosts());
     $(document).on('pun_preview', () => hidePreviewTags());
     $(document).on('pun_preedit', () => hidePreviewTags());
+    
+    //чтобы можно было заюзать призыв диалога заполнения маски по какой-нибудь иной кнопке
+    //например, добавленной чз FORUM.set или через утилитку от Ильи...
+    this.showMaskModalFunction = callMaskDialog;  
   }
 };


### PR DESCRIPTION
Чтобы можно было повесить открытие модалки на произвольную кнопку - есть люди, которые полностью переделывают форму ответа под себя, а стилизовать честно выдранную тдху в ровном ряду спанов выглядит костылем